### PR TITLE
Add timeout parameter to URE API requests and update URE answer format

### DIFF
--- a/get_ure_answer.py
+++ b/get_ure_answer.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 
-from rinna_ure import get_ure_answer
+from rinna_ure import get_ure_answers
 
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
@@ -14,5 +14,5 @@ if __name__ == "__main__":
     parser.add_argument("--l3ReturnNum", type=int, default=1, help="The number of L3 results to return. Defaults to 1.")
     args = parser.parse_args()
 
-    results = get_ure_answer(args.query, args.knowledgeSetId, args.l2ReturnNum, args.l3ReturnNum)
+    results = get_ure_answers(args.query, args.knowledgeSetId, args.l2ReturnNum, args.l3ReturnNum)
     print(results)

--- a/rinna_ure.py
+++ b/rinna_ure.py
@@ -2,7 +2,7 @@ import json
 import os
 import requests
 
-def upload_ure_knowledge(upload_file, is_file_overwrite=False):
+def upload_ure_knowledge(upload_file, is_file_overwrite=False, timeout=30):
     url = "https://api.rinna.co.jp/models/ure/v5.2/knowledge-file-upload"
     headers = {
         "Ocp-Apim-Subscription-Key": os.environ.get('RINNA_URE_SUBSCRIPTION_KEY')
@@ -10,14 +10,14 @@ def upload_ure_knowledge(upload_file, is_file_overwrite=False):
     params = {"is_file_overwrite": is_file_overwrite}
     files = {"upload_file": upload_file}
 
-    response = requests.post(url, headers=headers, params=params, files=files)
+    response = requests.post(url, headers=headers, params=params, files=files, timeout=timeout)
 
     if response.status_code == 200:
         return response.json()["knowledgeSetId"]
     else:
         raise Exception(f"Upload failed. status code {response.status_code}")
     
-def get_ure_answers(query, knowledgeSetId, l2ReturnNum=3, l3ReturnNum=1):
+def get_ure_answers(query, knowledgeSetId, l2ReturnNum=3, l3ReturnNum=1, timeout=30):
     url = "https://api.rinna.co.jp/models/ure/v5.2"
     headers = {
         "Content-Type": "application/json",
@@ -30,7 +30,7 @@ def get_ure_answers(query, knowledgeSetId, l2ReturnNum=3, l3ReturnNum=1):
         "l2ReturnNum": l2ReturnNum,
         "l3ReturnNum": l3ReturnNum
     }
-    response = requests.post(url, headers=headers, data=json.dumps(data))
+    response = requests.post(url, headers=headers, data=json.dumps(data), timeout=timeout);
     if response.status_code != 200:
         raise Exception(f"Failed to get answer. status code {response.status_code}")
     json_response = response.json()

--- a/rinna_ure.py
+++ b/rinna_ure.py
@@ -17,7 +17,7 @@ def upload_ure_knowledge(upload_file, is_file_overwrite=False):
     else:
         raise Exception(f"Upload failed. status code {response.status_code}")
     
-def get_ure_answer(query, knowledgeSetId, l2ReturnNum=3, l3ReturnNum=1):
+def get_ure_answers(query, knowledgeSetId, l2ReturnNum=3, l3ReturnNum=1):
     url = "https://api.rinna.co.jp/models/ure/v5.2"
     headers = {
         "Content-Type": "application/json",
@@ -36,5 +36,5 @@ def get_ure_answer(query, knowledgeSetId, l2ReturnNum=3, l3ReturnNum=1):
     json_response = response.json()
     l3_docs_list = json_response["l3DocsList"]
     l3_scores_list = json_response["l3ScoresList"]
-    results = [{"answer": l3_docs_list[0][i], "score": l3_scores_list[0][i]} for i in range(min(l3ReturnNum, len(l3_docs_list[0])))]
+    results = [{"document": l3_docs_list[0][i], "score": l3_scores_list[0][i]} for i in range(min(l3ReturnNum, len(l3_docs_list[0])))]
     return results

--- a/urechat_sample.py
+++ b/urechat_sample.py
@@ -2,8 +2,9 @@ import os
 import argparse
 import openai
 import time
+import random
 
-from rinna_ure import get_ure_answer
+from rinna_ure import get_ure_answers
 
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
@@ -15,7 +16,7 @@ if __name__ == "__main__":
 
 
     user_query = args.query
-    knowledge = get_ure_answer(user_query, os.environ.get('URE_KNOWLEDGE_SET_ID'))
+    knowledge = random_element = random.choice(get_ure_answers(user_query, os.environ.get('URE_KNOWLEDGE_SET_ID')))
     print(f"knowledge: {knowledge}")
 
     order="""あなたは乙女ゲームの悪役令嬢です。以下の設定に従い、ユーザと会話してください
@@ -36,7 +37,7 @@ example_conversation:
       messages=[
         {"role": "system", "content": order},
         {"role": "user", "content": user_query},
-        {"role": "system", "content": f"knowledge: {knowledge}"},
+        {"role": "system", "content": f"knowledge: {knowledge['document']}"},
         {"role": "system", "content": attention},
       ]
     )


### PR DESCRIPTION
Changes to rinna_ure.py:
- Added a `timeout` parameter to the `upload_ure_knowledge` function, allowing the timeout duration for API requests to be specified.
- Updated the `requests.post` calls to use the `timeout` parameter.
- Added a `timeout` parameter to the `get_ure_answers` function, allowing the timeout duration for API requests to be specified.
- Changed the format of URE answers. Specifically, I updated the `answer` key in the dictionary returned by `get_ure_answers` to be named `document`. 

Changes to urechat_sample.py:
- Changed the call to `get_ure_answer` to `get_ure_answers`.
- Updated the `knowledge` variable to return a random answer document.
- Updated the format of system messages to match the new answer format.
